### PR TITLE
Upgrade to PHP 8.2; replace `memcache` pecl workaround

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -1,4 +1,4 @@
-name: Build and push to Docker Hub as successatschool/docker-sas-web:php7.4
+name: Build and push to Docker Hub as successatschool/docker-sas-web:php8.2
 
 on:
   push:
@@ -25,4 +25,4 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           push: true
-          tags: successatschool/docker-sas-web:php7.4
+          tags: successatschool/docker-sas-web:php8.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4-apache
+FROM php:8.2-apache
 
 # System packages inc. Node + npm
 RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
@@ -26,22 +26,7 @@ RUN a2enmod headers \
 # Extension config and install
 RUN docker-php-ext-configure gd --with-jpeg
 RUN docker-php-ext-install bcmath gd intl opcache pcntl pdo_mysql sockets
-RUN pecl install memcached && docker-php-ext-enable memcached
-
-# TODO retire memcache extension, once we've replaced the bundle using it with native
-# Symfony 3.4 sessions in Production.
-# Manual build needed to get memcache extension support on PHP 7.x
-# See https://stackoverflow.com/a/48380759/2803757 and https://github.com/LeaseWeb/LswMemcacheBundle#requirements
-RUN cd /usr/local/src/ \
- && wget https://github.com/remicollet/pecl-memcache/archive/issue-php73.zip \
- && unzip issue-php73.zip \
- && mv pecl-memcache-issue-php73 pecl-memcache-php7 \
- && cd pecl-memcache-php7 \
- && phpize \
- && ./configure --enable-memcache \
- && make \
- && cp modules/memcache.so /usr/local/lib/php/extensions/no-debug-non-zts-20190902 \
- && echo 'extension=memcache.so' > /usr/local/etc/php/conf.d/docker-php-ext-manual-memcache.ini
+RUN pecl install memcache memcached && docker-php-ext-enable memcache memcached
 
 # PHP configuration
 COPY config/php.ini /usr/local/etc/php/

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The repository must have a change pushed or the scheduled action enabled
 at least every 60 days for updates to continue being built and pushed. We might
 want to consider migrating this process to CircleCI to remove this requirement.
 
-The current tag is **successatschool/docker-sas-web:php7.4**.
+The current tag is **successatschool/docker-sas-web:php8.2**.
 
 See [the docs](https://github.com/marketplace/actions/build-and-push-docker-images?version=v2.7.0)
 for more on how and why CI and Dependabot are configured within `.github`.


### PR DESCRIPTION
The fork we needed for PHP 7.x compatibility some years ago is now redundant, and the relevant fix is part of the official repo at https://github.com/websupport-sk/pecl-memcache